### PR TITLE
Fixing issuer param in google qr api query (must be consistent with uri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :test do
   gem 'factory_girl_rails', '~> 1.2'
   gem 'nokogiri', '< 1.6.0', :platforms => :ruby_18
   gem 'timecop'
+  gem 'test-unit', '~> 3.0'
 end

--- a/lib/devise_google_authenticatable/controllers/helpers.rb
+++ b/lib/devise_google_authenticatable/controllers/helpers.rb
@@ -3,9 +3,8 @@ module DeviseGoogleAuthenticator
     module Helpers # :nodoc:
       def google_authenticator_qrcode(user, qualifier=nil, issuer=nil)
         issuer = user.class.ga_appname
-        issuer = "#{issuer} (#{Rails.env})" unless Rails.env.production?
+        issuer = "#{issuer}-#{Rails.env}" unless Rails.env.production?
         data = "otpauth://totp/#{user.email}?secret=#{user.gauth_secret}&issuer=#{issuer}"
-        data << "&issuer=#{issuer}" if !issuer.nil?
         data = Rack::Utils.escape(data)
         url = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=#{data}"
         return image_tag(url, :alt => 'Google Authenticator QRCode')

--- a/test/lib/devise_google_authenticatable/controllers/helpers_test.rb
+++ b/test/lib/devise_google_authenticatable/controllers/helpers_test.rb
@@ -5,7 +5,8 @@ class HelpersTest < ActiveSupport::TestCase
     include DeviseGoogleAuthenticator::Controllers::Helpers
 
     def setup
-		@user = User.new(valid_attributes({:email => 'helpers_test@test.com' }))
+	    @user = User.new(valid_attributes({:email => 'helpers_test@test.com' }))
+        User.ga_appname = 'SimpleApp'
 	end
 
     # fake image tag
@@ -13,9 +14,9 @@ class HelpersTest < ActiveSupport::TestCase
         src
     end
     test 'generate qrcode' do
-        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsApp%3Fsecret%3D", google_authenticator_qrcode(@user)
-        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsAppMyQualifier%3Fsecret%3D", google_authenticator_qrcode(@user, 'MyQualifier')
-        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsApp%3Fsecret%3D%26issuer%3DMyIssuer", google_authenticator_qrcode(@user, nil, 'MyIssuer')
-        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsAppMyQualifier%3Fsecret%3D%26issuer%3DMyIssuer", google_authenticator_qrcode(@user, 'MyQualifier', 'MyIssuer')
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40test.com%3Fsecret%3D%26issuer%3DSimpleApp-test", google_authenticator_qrcode(@user)
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40test.com%3Fsecret%3D%26issuer%3DSimpleApp-test", google_authenticator_qrcode(@user, 'MyQualifier')
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40test.com%3Fsecret%3D%26issuer%3DSimpleApp-test", google_authenticator_qrcode(@user, nil, 'MyIssuer')
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40test.com%3Fsecret%3D%26issuer%3DSimpleApp-test", google_authenticator_qrcode(@user, 'MyQualifier', 'MyIssuer')
     end
 end


### PR DESCRIPTION
    naming conventions)

[#114649863]