### PR TITLE
Using domain and subdomain as an issuer

### DIFF
--- a/lib/devise_google_authenticatable/controllers/helpers.rb
+++ b/lib/devise_google_authenticatable/controllers/helpers.rb
@@ -2,7 +2,7 @@ module DeviseGoogleAuthenticator
   module Controllers # :nodoc:
     module Helpers # :nodoc:
       def google_authenticator_qrcode(user, qualifier=nil, issuer=nil)
-        issuer = user.class.ga_appname
+        issuer = controller.env['SERVER_NAME']
         issuer = "#{issuer} (#{Rails.env})" unless Rails.env.production?
         issuer = Rack::Utils.escape(issuer)
         data = "otpauth://totp/#{user.email}?secret=#{user.gauth_secret}&issuer=#{issuer}"


### PR DESCRIPTION
We still have a problem with consistent issuer naming for admins and affiliates. The safest way is to use domain and subdomain as an issuer name. Thanks to this we don't have to remember to change the name in a config file or in the settings table.